### PR TITLE
Add line to Makefile to specify bash shell 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 #       https://github.com/koreader/koxtoolchain
 # NOTE: We want the "bare" variant of the TC env, to make sure we vendor the right stuff...
 #       i.e., source ~SVN/Configs/trunk/Kindle/Misc/x-compile.sh kobo env bare
+SHELL := /bin/bash
 ifdef CROSS_TC
 	CC:=$(CROSS_TC)-gcc
 	STRIP:=$(CROSS_TC)-strip


### PR DESCRIPTION
makefile relies on `pushd` which requires `bash` shell. This patch specifies the shell explicitly in the makefile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NiLuJe/kfmon/13)
<!-- Reviewable:end -->
