### PR TITLE
Implement Thumbnail Detection Fix for Kobo 5.6 variant

### DIFF
--- a/kfmon.c
+++ b/kfmon.c
@@ -1488,8 +1488,6 @@ static bool
 					db_version = sqlite3_column_int(stmt, 0);
 					DBGLOG("Database version: %d", db_version);
 				}
-				sqlite3_finalize(stmt);
-
 				if (db_version >= 191) {
 					// Implement the 5.6 variant, which preserves the dot for the file extension
 
@@ -1510,6 +1508,7 @@ static bool
 					// Fallback to the v5 variant
 					replace_invalid_chars(converted_book_path);
 				}
+				sqlite3_finalize(stmt);
 
 				ret = snprintf(thumbnail_path,
 					       sizeof(thumbnail_path),

--- a/kfmon.c
+++ b/kfmon.c
@@ -1470,7 +1470,7 @@ static bool
 				is_processed = true;
 			}
 
-			// If we didn't find any thumbnails, try the v5 / v5.6 variant
+			// If we didn't find any thumbnails, try the v5.6 variant, which preserves the dot before the file extension
 			if (thumbnails_count == 0U) {
 				char converted_book_path[sizeof(book_path)];
 				// No error checking, we've already validated that string's length in `watch_handler`
@@ -1480,35 +1480,19 @@ static bool
 					sizeof(book_path),
 					NOTRUNC);
 
-				// Check the database version to decide whether to preserve the dot for the file extension
-				int db_version = 0;
-				CALL_SQLITE(prepare_v2(db, "SELECT version FROM DbVersion LIMIT 1;", -1, &stmt, NULL));
-				rc = sqlite3_step(stmt);
-				if (rc == SQLITE_ROW) {
-					db_version = sqlite3_column_int(stmt, 0);
-					DBGLOG("Database version: %d", db_version);
+				// Separate the extension from the base path
+				char* ext = strrchr(converted_book_path, '.');
+				if (ext) {
+					*ext = '\0'; // Temporarily terminate the string to isolate the base path
 				}
-				if (db_version >= 191) {
-					// Implement the 5.6 variant, which preserves the dot for the file extension
 
-					// Separate the extension from the base path
-					char* ext = strrchr(converted_book_path, '.');
-					if (ext) {
-						*ext = '\0'; // Temporarily terminate the string to isolate the base path
-					}
+				// Replace invalid characters in the base path
+				replace_invalid_chars(converted_book_path);
 
-					// Replace invalid characters in the base path
-					replace_invalid_chars(converted_book_path);
-
-					// Reattach the extension if it exists
-					if (ext) {
-						*ext = '.'; // Restore the dot
-					}
-				} else {
-					// Fallback to the v5 variant
-					replace_invalid_chars(converted_book_path);
+				// Reattach the extension if it exists
+				if (ext) {
+					*ext = '.'; // Restore the dot
 				}
-				sqlite3_finalize(stmt);
 
 				ret = snprintf(thumbnail_path,
 					       sizeof(thumbnail_path),
@@ -1516,13 +1500,44 @@ static bool
 					       KFMON_TARGET_MOUNTPOINT,
 					       converted_book_path);
 				if (ret < 0 || (size_t) ret >= sizeof(thumbnail_path)) {
-					LOG(LOG_WARNING, "Couldn't build the thumbnail path string");
+					LOG(LOG_WARNING, "Couldn't build the v5.6 thumbnail path string");
 				}
-				DBGLOG("Checking for thumbnail '%s' . . .", thumbnail_path);
+
+				DBGLOG("Checking for v5.6 thumbnail '%s' . . .", thumbnail_path);
 				if (access(thumbnail_path, F_OK) == 0) {
 					thumbnails_count++;
 				} else {
-					LOG(LOG_INFO, "Thumbnail (%s) hasn't been parsed yet!", thumbnail_path);
+					LOG(LOG_INFO, "v5.6 thumbnail (%s) hasn't been parsed yet!", thumbnail_path);
+				}
+
+				// Got it? Then we're good to go!
+				if (thumbnails_count == 1U) {
+					is_processed = true;
+				}
+			}
+			// If no v5.6 thumbnails were found, we try the v5 variant, which DOES NOT preserve the dot for the file extension
+			if (thumbnails_count == 0U) {
+				char converted_book_path[sizeof(book_path)];
+				// No error checking, we've already validated that string's length in `watch_handler`
+				str5cpy(converted_book_path,
+					sizeof(converted_book_path),
+					book_path,
+					sizeof(book_path),
+					NOTRUNC);
+				replace_invalid_chars(converted_book_path);
+				ret = snprintf(thumbnail_path,
+					       sizeof(thumbnail_path),
+					       "%s/.kobo-images/%s",
+					       KFMON_TARGET_MOUNTPOINT,
+					       converted_book_path);
+				if (ret < 0 || (size_t) ret >= sizeof(thumbnail_path)) {
+					LOG(LOG_WARNING, "Couldn't build the v5 thumbnail path string");
+				}
+				DBGLOG("Checking for v5 thumbnail '%s' . . .", thumbnail_path);
+				if (access(thumbnail_path, F_OK) == 0) {
+					thumbnails_count++;
+				} else {
+					LOG(LOG_INFO, "v5 thumbnail (%s) hasn't been parsed yet!", thumbnail_path);
 				}
 
 				// Got it? Then we're good to go!


### PR DESCRIPTION
This pull request aims to account for the different thumbnail handling on Tolino devices with DbVersion 191 and above. For those newer versions, the dot before the file extension has to be preserved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/NiLuJe/kfmon/15)
<!-- Reviewable:end -->
